### PR TITLE
Updates: Controllers for Month report

### DIFF
--- a/controller/reports/balanceGet.js
+++ b/controller/reports/balanceGet.js
@@ -1,3 +1,43 @@
-const balanceGet = async (_, res) => {}
+const { HttpCode } = require('../../helpers/constants')
+const { Transaction } = require('../../model')
+
+const balanceGet = async (_, res) => {
+  const cashOutBalance = await getCashState(false)
+  const cashInBalance = await getCashState(true)
+  const balance = cashInBalance[0].total - cashOutBalance[0].total
+
+  res.status(HttpCode.OK).json({
+    status: 'success',
+    code: 200,
+    data: {
+      cashOutBalance: cashOutBalance[0].total,
+      cashInBalance: cashInBalance[0].total,
+      balance: balance,
+    },
+    message: `Total Balance: ${cashInBalance} - ${cashOutBalance} = ${balance}`,
+  })
+}
+
+async function getCashState(isIncoming) {
+  const pipeline = [
+    {
+      $match: {
+        cashIncome: isIncoming,
+      },
+    },
+    {
+      $group: {
+        _id: 'Cash',
+        total: {
+          $sum: '$value',
+        },
+      },
+    },
+  ]
+
+  const result = await Transaction.aggregate(pipeline)
+
+  return result
+}
 
 module.exports = balanceGet

--- a/controller/reports/forMonth.js
+++ b/controller/reports/forMonth.js
@@ -1,0 +1,33 @@
+const { Transaction } = require('../../model')
+
+const forMonth = async (isIncoming, year, month) => {
+  const pipeline = [
+    {
+      $match: {
+        $and: [
+          {
+            cashIncome: isIncoming,
+          },
+          {
+            year: `${year}`,
+          },
+          {
+            month: `${month}`,
+          },
+        ],
+      },
+    },
+    {
+      $sort: {
+        year: -1,
+        month: -1,
+      },
+    },
+  ]
+
+  const result = await Transaction.aggregate(pipeline)
+
+  return result
+}
+
+module.exports = forMonth

--- a/controller/reports/forMonth.js
+++ b/controller/reports/forMonth.js
@@ -3,6 +3,81 @@ const { Transaction } = require('../../model')
 const forMonth = async (isIncoming, year, month) => {
   const pipeline = [
     {
+      $facet: {
+        list: [
+          {
+            $match: {
+              cashIncome: isIncoming,
+              year: `${year}`,
+              month: `${month}`,
+            },
+          },
+          {
+            $sort: {
+              day: -1,
+            },
+          },
+        ],
+        totalCashOut: [
+          {
+            $match: {
+              cashIncome: false,
+              year: '2021',
+              month: '09',
+            },
+          },
+          {
+            $group: {
+              _id: 'cashOut',
+              total: {
+                $sum: '$value',
+              },
+            },
+          },
+        ],
+        totalCashIn: [
+          {
+            $match: {
+              cashIncome: true,
+              year: '2021',
+              month: '09',
+            },
+          },
+          {
+            $group: {
+              _id: 'cashIn',
+              total: {
+                $sum: '$value',
+              },
+            },
+          },
+        ],
+      },
+    },
+  ]
+
+  const result = await Transaction.aggregate(pipeline)
+
+  const transactionListMonth = result[0].list
+  const cashOutMonth = result[0].totalCashOut[0].total
+  const cashInMonth = result[0].totalCashIn[0].total
+
+  console.log(result[0].list)
+  console.log(result[0].totalCashOut)
+  console.log(result[0].totalCashIn)
+
+  return { transactionListMonth, cashOutMonth, cashInMonth }
+}
+
+module.exports = forMonth
+
+/*
+
+*/
+
+/*
+ [
+    {
       $match: {
         $and: [
           {
@@ -24,10 +99,4 @@ const forMonth = async (isIncoming, year, month) => {
       },
     },
   ]
-
-  const result = await Transaction.aggregate(pipeline)
-
-  return result
-}
-
-module.exports = forMonth
+*/

--- a/controller/reports/getIncomingsForMonth.js
+++ b/controller/reports/getIncomingsForMonth.js
@@ -4,14 +4,16 @@ const forMonth = require('./forMonth')
 const getIncomingsForMonth = async (req, res) => {
   const { year, month } = req.params
 
-  const result = await forMonth(true, year, month)
+  const { transactionListMonth, cashOutMonth, cashInMonth } = await forMonth(
+    true,
+    year,
+    month
+  )
 
   res.status(HttpCode.OK).json({
     status: 'success',
     code: 200,
-    data: {
-      result: result,
-    },
+    data: { transactionListMonth, cashOutMonth, cashInMonth },
     message: `Spending summary report for ${month} ${year} has been successufully prepared`,
   })
 }

--- a/controller/reports/getIncomingsForMonth.js
+++ b/controller/reports/getIncomingsForMonth.js
@@ -1,3 +1,19 @@
-const getIncomingsForMonth = async (_, res) => {}
+const { HttpCode } = require('../../helpers/constants')
+const forMonth = require('./forMonth')
+
+const getIncomingsForMonth = async (req, res) => {
+  const { year, month } = req.params
+
+  const result = await forMonth(true, year, month)
+
+  res.status(HttpCode.OK).json({
+    status: 'success',
+    code: 200,
+    data: {
+      result: result,
+    },
+    message: `Spending summary report for ${month} ${year} has been successufully prepared`,
+  })
+}
 
 module.exports = getIncomingsForMonth

--- a/controller/reports/getSpendingsForMonth.js
+++ b/controller/reports/getSpendingsForMonth.js
@@ -1,36 +1,12 @@
-const { Transaction } = require('../../model')
 const { HttpCode } = require('../../helpers/constants')
+const forMonth = require('./forMonth')
 
 const getSpendingsForMonth = async (req, res) => {
-  console.log(req.params)
-
   const { year, month } = req.params
 
-  const pipeline = [
-    {
-      $match: {
-        $and: [
-          {
-            cashIncome: false,
-          },
-          {
-            year: `${year}`,
-          },
-          {
-            month: `${month}`,
-          },
-        ],
-      },
-    },
-    {
-      $sort: {
-        year: -1,
-        month: -1,
-      },
-    },
-  ]
+  // const result = await Transaction.aggregate(pipeline)
 
-  const result = await Transaction.aggregate(pipeline)
+  const result = await forMonth(false, year, month)
 
   res.status(HttpCode.OK).json({
     status: 'success',

--- a/controller/reports/getSpendingsForMonth.js
+++ b/controller/reports/getSpendingsForMonth.js
@@ -4,16 +4,16 @@ const forMonth = require('./forMonth')
 const getSpendingsForMonth = async (req, res) => {
   const { year, month } = req.params
 
-  // const result = await Transaction.aggregate(pipeline)
-
-  const result = await forMonth(false, year, month)
+  const { transactionListMonth, cashOutMonth, cashInMonth } = await forMonth(
+    false,
+    year,
+    month
+  )
 
   res.status(HttpCode.OK).json({
     status: 'success',
     code: 200,
-    data: {
-      result: result,
-    },
+    data: { transactionListMonth, cashOutMonth, cashInMonth },
     message: `Spending summary report for ${month} ${year} has been successufully prepared`,
   })
 }

--- a/controller/reports/getSpendingsLastSixMonth.js
+++ b/controller/reports/getSpendingsLastSixMonth.js
@@ -2,23 +2,56 @@ const { Transaction } = require('../../model')
 const { HttpCode } = require('../../helpers/constants')
 
 const getSpendingsLastSixMonth = async (_, res) => {
+  const today = new Date()
+  const curYear = today.getFullYear().toString()
+  const curMonth = (today.getMonth() + 1).toString()
+
+  console.log(`Today is a day of ${curMonth}-${curYear}`)
+
   const pipeline = [
     {
+      $project: {
+        year: 1,
+        month: 1,
+        day: 1,
+        value: 1,
+        cashIncome: 1,
+        myNewDate: {
+          $toDate: {
+            $concat: ['$year', '-', '$month', '-', '$day'],
+          },
+        },
+      },
+    },
+    {
       $match: {
-        cashIncome: false,
+        myNewDate: {
+          $lte: new Date('2021-10'),
+        },
+        // myNewDate: {
+        //   $gte: new Date('2021-05'),
+        // },
       },
     },
     {
       $group: {
-        _id: '$month',
-        totalSum: {
+        _id: {
+          month: {
+            $month: '$myNewDate',
+          },
+          year: {
+            $year: '$myNewDate',
+          },
+        },
+        Total: {
           $sum: '$value',
         },
       },
     },
     {
       $sort: {
-        _id: -1,
+        '_id.year': -1,
+        '_id.month': -1,
       },
     },
     {

--- a/routes/api/reports.js
+++ b/routes/api/reports.js
@@ -33,7 +33,10 @@ router.get(
 
 // ===== Cash-In reports
 // GET Cash-In report for Month
-router.get('/cash-in/:year/month', controllerWrapper(ctrl.getIncomingsForMonth))
+router.get(
+  '/cash-in/:year/:month',
+  controllerWrapper(ctrl.getIncomingsForMonth)
+)
 
 // GET Cash-In report for last six month
 router.get(


### PR DESCRIPTION
В ответ на GET запрос по роуту "/api/reports/cash-out/:year/:month"
отдаётся:
1) список расходов за указанный год/месяц, 
2) сумма расходов за указанный год/месяц,
3) сумма доходов за указанный год/месяц

В ответ на GET запрос по роуту "/api/reports/cash-in/:year/:month"
отдается:
1) список доходов за указанный год/месяц, 
2) сумма расходов за указанный год/месяц,
3) сумма доходов за указанный год/месяц